### PR TITLE
Fixed path in change playlist details

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -509,7 +509,7 @@ function SpotifyWebApi(credentials) {
    */
   this.changePlaylistDetails = function(userId, playlistId, options) {
     var request = WebApiRequest.builder()
-      .withPath('/v1/users/' + userId + '/playlists/' + playlistId + '/tracks')
+      .withPath('/v1/users/' + userId + '/playlists/' + playlistId)
       .withHeaders({ 'Content-Type' : 'application/json' })
       .withBodyParameters(options)
       .build();


### PR DESCRIPTION
The correct path for the "Change Playlist Details" request is:
https://api.spotify.com/v1/users/{user_id}/playlists/{playlist_id}

As shown under "Endpoint" in the web api documentation here:
https://developer.spotify.com/web-api/change-playlist-details/

However, the path in the module had "/tracks" appended to the end of the correct path. 
