### PR TITLE
Specified the package repository location

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type" : "git",
-    "url" : "https://github.com/thelinmichael/spotify-web-api-node"
+    "url" : "https://github.com/thelinmichael/spotify-web-api-node.git"
   },
   "dependencies": {
     "restler": "~3.2.0",


### PR DESCRIPTION
Because npm keeps warning about it missing
