### PR TITLE
Request errors with invalid JSON formats display as strings

### DIFF
--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -30,7 +30,8 @@ var _getErrorObject = function(defaultMessage, err) {
   if (typeof err.error === 'object' && typeof err.error.message === 'string') {
     errorObject = new Error(err.error.message);
   } else {
-    errorObject = new Error(defaultMessage + '. JSON has unexpected format ' + err);
+    errorObject = new Error(defaultMessage + '. JSON has unexpected format '
+      + JSON.stringify(err));
   }
   return errorObject;
 };


### PR DESCRIPTION
Currently, if the error format isn't correct, the error is displayed as "[Object object]". This modification allows the error to be displayed with the message, even if it isn't the correct format.