### PR TITLE
Allow optionally setting API call Headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ The response object for the same request in earlier versions than to 2.0.0.
   }
 ```
 
+To support making API calls with specific headers you may pass in the desired headers under the `headers` key for any
+wrapper call that supports optional parameters; e.g. getting a playlist could have usage
+```javascript
+spotifyApi.getPlaylist('odesza','0uxUkSQHZVM7so7msXl9Ck', { headers: { 'If-None-Match': 'AAAANPBn03qInch471K02Rncz5IHWVja'} })
+  .then(function(data) {
+    if(data.statusCode !== 304)
+      console.log('Playlist information', data.body);
+    else
+      console.log('Use cached playlist information');
+  }, function(err) {
+    console.error(err);
+  });
+```
 
 ### More examples
 
@@ -244,7 +257,7 @@ spotifyApi.searchPlaylists('workout')
   });
 
 // Get tracks in an album
-spotifyApi.getAlbumTracks('41MnTivkwTO3UUJ8DrqEJJ', { limit : 5, offset : 1 })
+spotifyApi.getAlbumTracks('41MnTivkwTO3UUJ8DrqEJJ', { limit : 5, offset : 1, headers: {'If-None-Match':'cachedEtagValue'} })
   .then(function(data) {
     console.log(data.body);
   }, function(err) {
@@ -513,7 +526,7 @@ spotifyApi.getPlaylistsForCategory('party', {
 ### Nesting calls
 ```javascript
 // track detail information for album tracks
-spotifyApi.getAlbum('5U4W9E5WsYb2jUQWePT8Xm')
+spotifyApi.getAlbum('5U4W9E5WsYb2jUQWePT8Xm',{ headers: {'If-None-Match':'cachedEtagValue'} })
   .then(function(data) {
     return data.body.tracks.map(function(t) { return t.id; });
   })
@@ -732,6 +745,9 @@ api.getPlaylistTracks('thelinmichael', '3ktAYNcRHpazJ9qecm3ptn', { 'offset' : 1,
 ```
 
 ## Change log
+
+#### 2.1.0 (15 Mar 2015)
+- Allow setting API call Header values via optional `headers` parameters in calls that support optional parameters.
 
 #### 2.0.1 (2 Mar 2015)
 - Return WebApiError objects if error occurs during authentication.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-web-api-node",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "homepage": "https://github.com/thelinmichael/spotify-web-api-node",
   "description": "A Node.js wrapper for Spotify's Web API",
   "main": "src/spotify-web-api.js",
@@ -24,6 +24,11 @@
     "sinon": "~1.12.2"
   },
   "keywords": [
-    "spotify", "music", "api", "wrapper", "client", "web api"
+    "spotify",
+    "music",
+    "api",
+    "wrapper",
+    "client",
+    "web api"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-web-api-node",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "https://github.com/thelinmichael/spotify-web-api-node",
   "description": "A Node.js wrapper for Spotify's Web API",
   "main": "src/spotify-web-api.js",

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -24,9 +24,18 @@ function SpotifyWebApi(credentials) {
       return;
     }
     for (var key in options) {
-      if (key !== 'credentials') {
+      if (key !== 'credentials' && key !== 'headers') {
         request.addQueryParameter(key, options[key]);
       }
+    }
+  }
+
+  function _addHeaderParameters(request, options) {
+    if (!options) {
+      return;
+    }
+    for (var key in options) {
+      request.addHeaders(options);
     }
   }
 
@@ -761,6 +770,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,options.headers);
 
     var promise = _performRequest(HttpManager.get, request);
 

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -188,7 +188,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -237,7 +237,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, actualOptions);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -283,7 +283,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -332,7 +332,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, actualOptions);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -427,7 +427,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -463,7 +463,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise =  _performRequest(HttpManager.get, request);
 
@@ -499,7 +499,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -535,7 +535,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -567,7 +567,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -599,7 +599,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -749,7 +749,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -781,7 +781,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -813,7 +813,7 @@ function SpotifyWebApi(credentials) {
       build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -861,7 +861,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.post, request);
 
@@ -893,7 +893,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -956,7 +956,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1000,7 +1000,7 @@ function SpotifyWebApi(credentials) {
 
     _addQueryParameters(request, options);
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.post, request);
 
@@ -1037,7 +1037,7 @@ function SpotifyWebApi(credentials) {
 
     _addBodyParameters(request, options);
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1143,7 +1143,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addBodyParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise =  _performRequest(HttpManager.put, request);
 
@@ -1178,7 +1178,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addBodyParameters(request, options);
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise =  _performRequest(HttpManager.post, request);
 
@@ -1295,7 +1295,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1643,7 +1643,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1673,7 +1673,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise =  _performRequest(HttpManager.get, request);
 
@@ -1702,7 +1702,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1732,7 +1732,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1762,7 +1762,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
+    _addHeaderParameters(request,(options && options.headers ? options.headers : null));
 
     var promise = _performRequest(HttpManager.get, request);
 

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -188,6 +188,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -236,6 +237,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, actualOptions);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -281,6 +283,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -329,6 +332,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, actualOptions);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -357,6 +361,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -388,6 +393,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -423,6 +429,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -458,6 +465,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise =  _performRequest(HttpManager.get, request);
 
@@ -493,6 +501,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -528,6 +537,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -559,6 +569,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -590,6 +601,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -623,6 +635,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -651,6 +664,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -680,6 +694,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -709,6 +724,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -739,6 +755,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -770,7 +787,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addQueryParameters(request, options);
-    _addHeaderParameters(request,options.headers);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -802,6 +819,7 @@ function SpotifyWebApi(credentials) {
       build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -849,6 +867,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.post, request);
 
@@ -880,6 +899,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -910,6 +930,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -942,6 +963,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -985,6 +1007,7 @@ function SpotifyWebApi(credentials) {
 
     _addQueryParameters(request, options);
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.post, request);
 
@@ -1021,6 +1044,7 @@ function SpotifyWebApi(credentials) {
 
     _addBodyParameters(request, options);
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1056,6 +1080,7 @@ function SpotifyWebApi(credentials) {
       build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1089,6 +1114,7 @@ function SpotifyWebApi(credentials) {
       build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise =  _performRequest(HttpManager.put, request);
 
@@ -1126,6 +1152,7 @@ function SpotifyWebApi(credentials) {
 
     _addAccessToken(request, this.getAccessToken());
     _addBodyParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise =  _performRequest(HttpManager.put, request);
 
@@ -1160,6 +1187,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addBodyParameters(request, options);
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise =  _performRequest(HttpManager.post, request);
 
@@ -1276,6 +1304,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1308,6 +1337,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1337,6 +1367,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1365,6 +1396,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1397,6 +1429,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1429,6 +1462,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1461,6 +1495,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1493,6 +1528,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1527,6 +1563,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1560,6 +1597,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1594,6 +1632,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1623,6 +1662,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1652,6 +1692,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise =  _performRequest(HttpManager.get, request);
 
@@ -1680,6 +1721,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1709,6 +1751,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1738,6 +1781,7 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
+    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -361,7 +361,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -393,7 +392,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -635,7 +633,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -664,7 +661,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -694,7 +690,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -724,7 +719,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -930,7 +924,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1080,7 +1073,6 @@ function SpotifyWebApi(credentials) {
       build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1114,7 +1106,6 @@ function SpotifyWebApi(credentials) {
       build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise =  _performRequest(HttpManager.put, request);
 
@@ -1337,7 +1328,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1367,7 +1357,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1396,7 +1385,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1429,7 +1417,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1462,7 +1449,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.put, request);
 
@@ -1495,7 +1481,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1528,7 +1513,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.del, request);
 
@@ -1563,7 +1547,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1597,7 +1580,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 
@@ -1632,7 +1614,6 @@ function SpotifyWebApi(credentials) {
       .build();
 
     _addAccessToken(request, this.getAccessToken());
-    _addHeaderParameters(request,(options.headers || null));
 
     var promise = _performRequest(HttpManager.get, request);
 


### PR DESCRIPTION
**thelinmichael's** work to provide access to response headers in PR #25 is awesome, this PR completes the loop by allowing users to set the Header values when making API calls.