### PR TITLE
Bug fix case of JSON serialized error object

### DIFF
--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -38,10 +38,21 @@ var _getErrorObject = function(defaultMessage, err) {
     /* jshint ignore:start */
     errorObject = new WebApiError(err.error + ': ' + err['error_description']);
     /* jshint ignore:end */
-  } else {
+  } else if (typeof err === 'string') {
+    // Serialized JSON error
+    try {
+      var parsedError = JSON.parse(err);
+      errorObject = new WebApiError(parsedError.error.message, parsedError.error.status);
+    } catch (err) { 
+      // Error not JSON formatted
+    }
+  }
+
+  if(!errorObject) {
     // Unexpected format
     errorObject = new WebApiError(defaultMessage + ': ' + JSON.stringify(err));
   }
+
   return errorObject;
 };
 

--- a/test/http-manager.js
+++ b/test/http-manager.js
@@ -146,6 +146,33 @@ describe("Make requests", function() {
       });
     });
 
+    it("Should process a failing GET request with a JSON string formatted error object with message and status", function(done) {
+
+      useRestlerMock({
+        method: 'get',
+        event: 'fail',
+        response: {
+          data: '{ "error": { "message": "API rate limit exceeded", "status": 429 } }',
+          headers: {},
+          statusCode: 429
+        }
+      });
+
+      var HttpManager = require('../src/http-manager');
+      var request = Request.builder()
+        .withHost("such.api.wow")
+        .withPort(1337)
+        .withScheme("http")
+        .build();
+
+      HttpManager.get(request, function(errorObject) {
+        errorObject.should.be.an.instanceOf(Error);
+        errorObject.message.should.equal('API rate limit exceeded');
+        errorObject.statusCode.should.equal(429)
+        done();
+      });
+    });
+
     it("Should process a failing GET request with a Web API error object with message", function(done) {
 
       useRestlerMock({


### PR DESCRIPTION
This fixes an issue presented when receiving a JSON string representing the error object. 

An example case is the 429 rate limit error.
```
'{ "error": { "status": 429,  "message": "API rate limit exceeded" } }'
```

This ensures a correct WebApiError is created for these cases.