### PR TITLE
Fix recommendations endpoint

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1146,15 +1146,23 @@ function SpotifyWebApi(credentials) {
 
   /**
    * Create a playlist-style listening experience based on seed artists, tracks and genres.
-   * @param {Object} [options] The options supplied to this request.
+   * @param {Object} [seeds] At least one of seed_tracks, seed_artists or seed_genres must be supplied. Eg. { seed_artists: ['0oSGxfWSnnOXhD2fKuz2Gy'] }
+   * @param {Object} [options] Optional parameters supplied to this request.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
    * @example getRecommendations({ min_energy: 0.4, seed_artists: ['6mfK6Q2tzLMEchAr0e9Uzu', '4DYFVNKZ1uixa6SQTvzQwJ'], min_popularity: 50 }).then(...)
    * @returns {Promise|undefined} A promise that if successful, resolves to an object containing
    *          a list of tracks and a list of seeds. If rejected, it contains an error object. Not returned if a callback is given.
    */
-  this.getRecommendations = function(options, callback) {
+  this.getRecommendations = function(seeds, options, callback) {
+    var actualSeeds = {};
+
+    Object.keys(seeds).forEach(function(key) {
+        actualSeeds[key] = seeds[key].join(',')
+    });
+
     var request = WebApiRequest.builder()
       .withPath('/v1/recommendations')
+      .withQueryParameters(actualSeeds)
       .build();
 
     _addAccessToken(request, this.getAccessToken());

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -2554,7 +2554,7 @@ describe('Spotify Web API', function() {
       options.query.should.eql({
         min_energy : 0.4,
         market : 'ES',
-        seed_artists : ['6mfK6Q2tzLMEchAr0e9Uzu', '4DYFVNKZ1uixa6SQTvzQwJ'],
+        seed_artists : '6mfK6Q2tzLMEchAr0e9Uzu,4DYFVNKZ1uixa6SQTvzQwJ',
         limit : 5,
         min_popularity : 50
       });
@@ -2569,10 +2569,13 @@ describe('Spotify Web API', function() {
 
     var api = new SpotifyWebApi();
 
-    api.getRecommendations({
+    api.getRecommendations(
+      {
+        seed_artists: ['6mfK6Q2tzLMEchAr0e9Uzu', '4DYFVNKZ1uixa6SQTvzQwJ']
+      },
+      {
         min_energy : 0.4,
         market : 'ES',
-        seed_artists : ['6mfK6Q2tzLMEchAr0e9Uzu', '4DYFVNKZ1uixa6SQTvzQwJ'],
         limit : 5,
         min_popularity : 50
       })


### PR DESCRIPTION
Heyo!

The recommendations endpoint doesn't support seeds passed as an array. It has to be passed as a comma-separated string. This PR fixes this.

This changes how you need to call the method. Please let me know if you have another preferred of solving this :)

First argument is for the required seeds (you need at least one of `seed_artists`, `seed_tracks`, `seed_genres`), and the second is for optional options.

```js
// New way
spotifyApi.getRecommendations({
  seed_artists: ['0k17h0D3J5VfsdmQ1iZtE9'] // Still uses array in call
}, [optional options], [cb])

// Old way
spotifyApi.getRecommendations({
  seed_artists: ['0k17h0D3J5VfsdmQ1iZtE9'],
 // more params (required and optional mixed)
}, [cb])

```