### PR TITLE
Use superagent instead of restler - Fixes #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Even though authentication isn't always necessary, it always gives benefits such
 
 ##### Dependencies
 
-This project depends on [restler](https://github.com/danwrong/restler) to make HTTP requests, and [promise](https://github.com/then/promise) as its [Promises/A+](http://promises-aplus.github.io/promises-spec/) implementation.
+This project depends on [superagent](https://github.com/visionmedia/superagent) to make HTTP requests, and [promise](https://github.com/then/promise) as its [Promises/A+](http://promises-aplus.github.io/promises-spec/) implementation.
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/thelinmichael/spotify-web-api-node.git"
   },
   "dependencies": {
-    "restler": "~3.2.0",
-    "promise": "~5.0.0"
+    "promise": "~5.0.0",
+    "superagent": "^2.0.0"
   },
   "config": {
     "blanket": {
@@ -21,7 +21,7 @@
     }
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha",
+    "test": "./node_modules/.bin/mocha --bail",
     "coveralls": "./node_modules/.bin/mocha -r blanket -R mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js"
   },
   "devDependencies": {

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1,4 +1,4 @@
-var restler = require('restler'),
+var superagent = require('superagent'),
     HttpManager = require('../src/http-manager'),
     sinon = require('sinon'),
     SpotifyWebApi = require('../src/spotify-web-api'),
@@ -42,7 +42,7 @@ describe('Spotify Web API', function() {
 
   it("should retrieve track metadata", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/tracks/3Qm86XLflmIXVm1wcwkgDK');
       should.not.exist(options.data);
       callback(null, { body : { "uri" : "spotify:track:3Qm86XLflmIXVm1wcwkgDK" }, headers : { "cache-control" : "public, max-age=7200" }, statusCode : 200 });
@@ -62,7 +62,7 @@ describe('Spotify Web API', function() {
 
   it("should retrieve error when retrieving track metadata", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/tracks/3Qm86XLflmIXVm1wcwkgDK');
       should.not.exist(options.data);
       callback(new WebApiError("Do NOT do that again!", 400));
@@ -81,7 +81,7 @@ describe('Spotify Web API', function() {
 
   it("should get track for Swedish market", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/tracks/3Qm86XLflmIXVm1wcwkgDK');
       options.query.market.should.equal('SE');
       should.not.exist(options.data);
@@ -99,7 +99,7 @@ describe('Spotify Web API', function() {
 
   it("should retrieve track metadata using callback", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/tracks/3Qm86XLflmIXVm1wcwkgDK');
       should.not.exist(options.data);
       callback();
@@ -115,7 +115,7 @@ describe('Spotify Web API', function() {
   it("should fail for non existing track id", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       callback(new WebApiError('non existing id', 400));
     });
 
@@ -133,7 +133,7 @@ describe('Spotify Web API', function() {
   it("should fail for non existing track id using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       callback(new WebApiError('non existing id', 400), null);
     });
 
@@ -149,7 +149,7 @@ describe('Spotify Web API', function() {
   it('should fail for empty track id', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       callback(new WebApiError('Fail', 400), null);
     });
 
@@ -166,7 +166,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for several tracks", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/tracks');
       options.query.ids.should.equal('0eGsygTp906u18L0Oimnem,1lDWb6b6ieDQ2xT7ewTC3G');
       should.not.exist(options.data);
@@ -185,7 +185,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for several tracks using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/tracks');
       options.query.ids.should.equal('0eGsygTp906u18L0Oimnem,1lDWb6b6ieDQ2xT7ewTC3G');
       should.not.exist(options.data);
@@ -202,7 +202,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for an album", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums/0sNOF9WDwhWunNAHPD3Baj');
       should.not.exist(options.data);
       callback(null, { body : { uri : 'spotify:album:0sNOF9WDwhWunNAHPD3Baj'}, statusCode : 200 });
@@ -222,7 +222,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for an album for a market ", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums/0sNOF9WDwhWunNAHPD3Baj');
       should.not.exist(options.data);
       options.query.market.should.equal('SE');
@@ -243,7 +243,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for an album using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums/0sNOF9WDwhWunNAHPD3Baj');
       should.not.exist(options.data);
       callback(null, { body : { uri: 'spotify:album:0sNOF9WDwhWunNAHPD3Baj' }, statusCode : 200 });
@@ -261,7 +261,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for several albums", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums');
       options.query.ids.should.equal('41MnTivkwTO3UUJ8DrqEJJ,6JWc4iAiJ9FjyK0B59ABb4');
       should.not.exist(options.data);
@@ -286,7 +286,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for several albums using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums');
       options.query.ids.should.equal('41MnTivkwTO3UUJ8DrqEJJ,6JWc4iAiJ9FjyK0B59ABb4');
       should.not.exist(options.data);
@@ -309,7 +309,7 @@ describe('Spotify Web API', function() {
   it("should retrive metadata for an artist", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0LcJLqbBmaGUft1e9Mm8HV');
       should.not.exist(options.data);
       callback(null, {body: {uri: 'spotify:artist:0LcJLqbBmaGUft1e9Mm8HV'}});
@@ -328,7 +328,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for an artist using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0LcJLqbBmaGUft1e9Mm8HV');
       should.not.exist(options.data);
       callback(null, {body: {uri: 'spotify:artist:0LcJLqbBmaGUft1e9Mm8HV'}});
@@ -345,7 +345,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for several artists", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists');
       options.query.ids.should.equal('0oSGxfWSnnOXhD2fKuz2Gy,3dBVyJ7JuOMt4GE9607Qin');
       should.not.exist(options.data);
@@ -370,7 +370,7 @@ describe('Spotify Web API', function() {
   it("should retrieve metadata for several artists using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists');
       options.query.ids.should.equal('0oSGxfWSnnOXhD2fKuz2Gy,3dBVyJ7JuOMt4GE9607Qin');
       should.not.exist(options.data);
@@ -393,7 +393,7 @@ describe('Spotify Web API', function() {
   it("should search for an album using limit and offset", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 3,
@@ -431,7 +431,7 @@ describe('Spotify Web API', function() {
   it("should search for an album using limit and offset using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 3,
@@ -459,7 +459,7 @@ describe('Spotify Web API', function() {
 
   it("should search for playlists", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 1,
@@ -491,7 +491,7 @@ describe('Spotify Web API', function() {
   it("should search for an artist using limit and offset", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 5,
@@ -522,7 +522,7 @@ describe('Spotify Web API', function() {
   it("should search for an artist using limit and offset using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 5,
@@ -551,7 +551,7 @@ describe('Spotify Web API', function() {
   it("should search for a track using limit and offset", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 3,
@@ -583,7 +583,7 @@ describe('Spotify Web API', function() {
   it("should search for a track using limit and offset using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 3,
@@ -612,7 +612,7 @@ describe('Spotify Web API', function() {
   it("should search for several types using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/search/');
       options.query.should.eql({
         limit: 3,
@@ -641,7 +641,7 @@ describe('Spotify Web API', function() {
   it("should get artists albums", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0oSGxfWSnnOXhD2fKuz2Gy/albums');
       options.query.should.eql({
         album_type: 'album',
@@ -671,7 +671,7 @@ describe('Spotify Web API', function() {
   it("should get artists albums using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0oSGxfWSnnOXhD2fKuz2Gy/albums');
       options.query.should.eql({
         album_type: 'album',
@@ -698,7 +698,7 @@ describe('Spotify Web API', function() {
   it("should get tracks from album", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums/41MnTivkwTO3UUJ8DrqEJJ/tracks');
       options.query.should.eql({
         offset: 1,
@@ -725,7 +725,7 @@ describe('Spotify Web API', function() {
   it("should get tracks from album using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/albums/41MnTivkwTO3UUJ8DrqEJJ/tracks');
       options.query.should.eql({
         offset: 1,
@@ -750,7 +750,7 @@ describe('Spotify Web API', function() {
   it("should get top tracks for artist", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0oSGxfWSnnOXhD2fKuz2Gy/top-tracks');
       options.query.should.eql({
         country: 'GB'
@@ -772,7 +772,7 @@ describe('Spotify Web API', function() {
   it("should get top tracks for artist", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0oSGxfWSnnOXhD2fKuz2Gy/top-tracks');
       options.query.should.eql({
         country: 'GB'
@@ -792,7 +792,7 @@ describe('Spotify Web API', function() {
   it("should get similar artists", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0qeei9KQnptjwb8MgkqEoy/related-artists');
       should.not.exist(options.data);
       callback(null, {
@@ -816,7 +816,7 @@ describe('Spotify Web API', function() {
   it("should get similar artists using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/artists/0qeei9KQnptjwb8MgkqEoy/related-artists');
       should.not.exist(options.data);
       callback(null, {
@@ -837,7 +837,7 @@ describe('Spotify Web API', function() {
   it("should get a user", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/users/petteralexis');
       should.not.exist(options.data);
       callback(null,
@@ -862,7 +862,7 @@ describe('Spotify Web API', function() {
   it("should get a user using callback", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/users/petteralexis');
       should.not.exist(options.data);
       callback(null, {
@@ -884,7 +884,7 @@ describe('Spotify Web API', function() {
   it("should get the authenticated user's information", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me');
       options.headers.should.eql({Authorization: 'Bearer someAccessToken'});
       callback(null, {
@@ -908,7 +908,7 @@ describe('Spotify Web API', function() {
   it("should get the authenticated user's information with accesstoken set on the api object", function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me');
       options.headers.should.eql({Authorization: 'Bearer someAccessToken'});
       callback(null, {
@@ -931,7 +931,7 @@ describe('Spotify Web API', function() {
   it('should fail if no token is provided for a request that requires an access token', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me');
       if (!options.headers || !options.headers.Authorization) {
         callback(new WebApiError('No token', 401), null);
@@ -953,7 +953,7 @@ describe('Spotify Web API', function() {
   it('should fail if no token is provided for a request that requires an access token using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me');
       if (!options.headers || !options.headers.Authorization) {
         callback(new WebApiError('No token', 401), null);
@@ -972,7 +972,7 @@ describe('Spotify Web API', function() {
 
   it('should get a users playlists', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists');
       should.not.exist(options.query);
       callback(null, { body : { items: [
@@ -995,7 +995,7 @@ describe('Spotify Web API', function() {
 
   it('should get a playlist', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK');
       should.not.exist(options.query);
       callback(null, { body : { uri : 'spotify:user:thelinmichael:playlist:5ieJqeLJjjI8iJWaxeBLuK'}, statusCode : 200 });
@@ -1026,7 +1026,7 @@ describe('Spotify Web API', function() {
 
   it('should create a private playlist using callback', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists');
       JSON.parse(options.data).should.eql({ name : 'My Cool Playlist', 'public' : false });
       should.not.exist(options.query);
@@ -1044,7 +1044,7 @@ describe('Spotify Web API', function() {
 
   it('should create a playlist using callback without options', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists');
       JSON.parse(options.data).should.eql({ name : 'My Cool Playlist' })
       callback(null, { body: { name : 'My Cool Playlist' } });
@@ -1060,7 +1060,7 @@ describe('Spotify Web API', function() {
 
   it('should change playlist details', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK');
       JSON.parse(options.data).should.eql({
         name : 'This is a new name for my Cool Playlist, and will become private',
@@ -1084,7 +1084,7 @@ describe('Spotify Web API', function() {
 
   it('should add tracks to playlist', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
       options.query.should.eql({uris: 'spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M'});
       callback(null, { body: { snapshot_id: 'aSnapshotId'}, statusCode : 201 });
@@ -1102,7 +1102,7 @@ describe('Spotify Web API', function() {
 
   it('should add tracks to playlist with specified index', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       options.query.should.eql({
         uris: 'spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M',
         position: 10
@@ -1125,7 +1125,7 @@ describe('Spotify Web API', function() {
 
   it("should get user's top artists", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/top/artists');
       options.query.should.eql({
         limit : 5
@@ -1151,7 +1151,7 @@ describe('Spotify Web API', function() {
 
   it("should get user's top tracks", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/top/tracks');
       options.query.should.eql({
         limit : 5
@@ -1244,7 +1244,7 @@ describe('Spotify Web API', function() {
 
   it('should refresh an access token', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       uri.should.equal('https://accounts.spotify.com/api/token');
       options.data.should.eql({ grant_type : 'refresh_token', refresh_token : 'someLongRefreshToken' });
       should.not.exist(options.query);
@@ -1386,7 +1386,7 @@ describe('Spotify Web API', function() {
   it('should remove tracks in the users library', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       JSON.parse(options.data).should.eql(["3VNWq8rTnQG6fM1eldSpZ0"]);
       uri.should.equal('https://api.spotify.com/v1/me/tracks');
       should.not.exist(options.query);
@@ -1412,7 +1412,7 @@ describe('Spotify Web API', function() {
   it('should remove albums in the users library', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       JSON.parse(options.data).should.eql(["27cZdqrQiKt3IT00338dws"]);
       uri.should.equal('https://api.spotify.com/v1/me/albums');
       should.not.exist(options.query);
@@ -1438,7 +1438,7 @@ describe('Spotify Web API', function() {
   it('should add albums to the users library', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       JSON.parse(options.data).should.eql(["27cZdqrQiKt3IT00338dws"]);
       uri.should.equal('https://api.spotify.com/v1/me/albums');
       should.not.exist(options.query);
@@ -1463,7 +1463,7 @@ describe('Spotify Web API', function() {
 
   it('should get albums in the users library', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/albums');
       options.headers.Authorization.should.equal('Bearer myAccessToken');
       options.query.limit.should.equal(2);
@@ -1494,7 +1494,7 @@ describe('Spotify Web API', function() {
 
   it('should determine if an album is in the users library', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/albums/contains');
       options.headers.Authorization.should.equal('Bearer myAccessToken');
       options.query.ids.should.equal("27cZdqrQiKt3IT00338dws");
@@ -1521,7 +1521,7 @@ describe('Spotify Web API', function() {
 
   it('should follow a playlist', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       JSON.parse(options.data).should.eql({ public: false });
       should.not.exist(options.query);
       uri.should.equal('https://api.spotify.com/v1/users/jmperezperez/playlists/7p9EIC2KW0NNkTEOnTUZJl/followers');
@@ -1545,7 +1545,7 @@ describe('Spotify Web API', function() {
 
   it('should unfollow a playlist', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       should.not.exist(options.data);
       should.not.exist(options.query);
       uri.should.equal('https://api.spotify.com/v1/users/jmperezperez/playlists/7p9EIC2KW0NNkTEOnTUZJl/followers');
@@ -1570,7 +1570,7 @@ describe('Spotify Web API', function() {
   it('should follow several users', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'user',
@@ -1599,7 +1599,7 @@ describe('Spotify Web API', function() {
   it('should follow several users using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'user',
@@ -1625,7 +1625,7 @@ describe('Spotify Web API', function() {
   it('should follow several artists', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'artist',
@@ -1654,7 +1654,7 @@ describe('Spotify Web API', function() {
   it('should follow several artists using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'artist',
@@ -1679,7 +1679,7 @@ describe('Spotify Web API', function() {
   it('should unfollow several users', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'user',
@@ -1708,7 +1708,7 @@ describe('Spotify Web API', function() {
   it('should unfollow several users using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'user',
@@ -1733,7 +1733,7 @@ describe('Spotify Web API', function() {
   it('should unfollow several artists', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'artist',
@@ -1762,7 +1762,7 @@ describe('Spotify Web API', function() {
   it('should unfollow several artists using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'artist',
@@ -1788,7 +1788,7 @@ describe('Spotify Web API', function() {
   it('should check whether the current user follows several other users', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/following/contains');
       options.query.should.eql({
         type: 'user',
@@ -1820,7 +1820,7 @@ describe('Spotify Web API', function() {
   it('should check whether the current user follows several other users using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/following/contains');
       options.query.should.eql({
         type: 'user',
@@ -1848,7 +1848,7 @@ describe('Spotify Web API', function() {
   it('should check whether the current user follows several artists', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/following/contains');
       options.query.should.eql({
         type: 'artist',
@@ -1879,7 +1879,7 @@ describe('Spotify Web API', function() {
   it('should check whether the current user follows several artists using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/following/contains');
       options.query.should.eql({
         type: 'artist',
@@ -1906,7 +1906,7 @@ describe('Spotify Web API', function() {
 
   it('should get a user\'s followed artists using callback', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'artist',
@@ -1934,7 +1934,7 @@ describe('Spotify Web API', function() {
 
   it('should get a user\'s followed artists using callback', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/following');
       options.query.should.eql({
         type: 'artist',
@@ -1961,7 +1961,7 @@ describe('Spotify Web API', function() {
   it('should check whether users follows a playlist', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/users/spotify_germany/playlists/2nKFnGNFvHX9hG5Kv7Bm3G/followers/contains');
       options.query.should.eql({
         ids: 'thelinmichael,ella'
@@ -1992,7 +1992,7 @@ describe('Spotify Web API', function() {
   it('should add tracks to playlist', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
       var trackUris = options.query.uris.split(",");
       trackUris.should.be.an.instanceOf(Array).and.have.lengthOf(2);
@@ -2016,7 +2016,7 @@ describe('Spotify Web API', function() {
   it('should add tracks to playlist using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.post);
+      method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
       var trackUris = options.query.uris.split(",");
       trackUris.should.be.an.instanceOf(Array).and.have.lengthOf(2);
@@ -2035,7 +2035,7 @@ describe('Spotify Web API', function() {
 
   it("should remove tracks from a playlist by position", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.del);
+      method.should.equal(superagent.del);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
       should.not.exist(options.query);
       JSON.parse(options.data).positions[0].should.equal(0);
@@ -2060,7 +2060,7 @@ describe('Spotify Web API', function() {
 
   it("should reorder tracks from a playlist by position", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
       should.not.exist(options.query);
       JSON.parse(options.data)["range_start"].should.equal(5);
@@ -2093,7 +2093,7 @@ describe('Spotify Web API', function() {
   it('should add tracks to the users library', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       JSON.parse(options.data).should.eql(["3VNWq8rTnQG6fM1eldSpZ0"]);
       uri.should.equal('https://api.spotify.com/v1/me/tracks');
       should.not.exist(options.query);
@@ -2119,7 +2119,7 @@ describe('Spotify Web API', function() {
   it('should add tracks to the users library using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       JSON.parse(options.data).should.eql(["3VNWq8rTnQG6fM1eldSpZ0"]);
       uri.should.equal('https://api.spotify.com/v1/me/tracks');
       should.not.exist(options.query);
@@ -2142,7 +2142,7 @@ describe('Spotify Web API', function() {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
 
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       JSON.parse(options.data).should.eql(["3VNWq8rTnQG6fM1eldSpZ0"]);
       uri.should.equal('https://api.spotify.com/v1/me/tracks');
       should.not.exist(options.query);
@@ -2171,7 +2171,7 @@ describe('Spotify Web API', function() {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
 
-      method.should.equal(restler.put);
+      method.should.equal(superagent.put);
       JSON.parse(options.data).should.eql(["3VNWq8rTnQG6fM1eldSpZ0"]);
       uri.should.equal('https://api.spotify.com/v1/me/tracks');
       should.not.exist(options.query);
@@ -2196,7 +2196,7 @@ describe('Spotify Web API', function() {
   it('should get new releases', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/new-releases');
       options.query.should.eql({
         limit: 5,
@@ -2237,7 +2237,7 @@ describe('Spotify Web API', function() {
   it('should get new releases', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/new-releases');
       options.query.should.eql({
         limit: 5,
@@ -2279,7 +2279,7 @@ describe('Spotify Web API', function() {
   it('should get featured playlists', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/featured-playlists');
       options.query.should.eql({
         limit: 3,
@@ -2328,7 +2328,7 @@ describe('Spotify Web API', function() {
   it('should get featured playlists using callback', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/featured-playlists');
       options.query.should.eql({
         limit: 3,
@@ -2374,7 +2374,7 @@ describe('Spotify Web API', function() {
   it('should get browse categories', function(done) {
 
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/categories');
       options.query.should.eql({
         limit : 2,
@@ -2417,7 +2417,7 @@ describe('Spotify Web API', function() {
 
   it('should get a browse category', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/categories/party');
       options.query.should.eql({
         country : 'SE',
@@ -2453,7 +2453,7 @@ describe('Spotify Web API', function() {
 
   it('should get a playlists for a browse category', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/browse/categories/party/playlists');
       options.query.should.eql({
         country : 'SE',
@@ -2498,7 +2498,7 @@ describe('Spotify Web API', function() {
 
   it("should get the audio features for a track", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/audio-features/3Qm86XLflmIXVm1wcwkgDK');
       should.not.exist(options.query);
       should.not.exist(options.data);
@@ -2523,7 +2523,7 @@ describe('Spotify Web API', function() {
 
   it("should get the audio features for a several tracks", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/audio-features');
       options.query.should.eql({
         ids : '3Qm86XLflmIXVm1wcwkgDK,1lDWb6b6ieDQ2xT7ewTC3G'
@@ -2549,7 +2549,7 @@ describe('Spotify Web API', function() {
 
   it("should get recommendations", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/recommendations');
       options.query.should.eql({
         min_energy : 0.4,
@@ -2586,7 +2586,7 @@ describe('Spotify Web API', function() {
 
   it("should get recommendations using an array of seeds", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/recommendations');
       options.query.should.eql({
         min_energy : 0.4,
@@ -2623,7 +2623,7 @@ describe('Spotify Web API', function() {
 
   it("should get available genre seeds", function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/recommendations/available-genre-seeds');
       should.not.exist(options.query);
       should.not.exist(options.data);


### PR DESCRIPTION
Tried to touch the least amount of code as possible, but some of the tests needed to be changed. Mainly the timeout tests were removed, as I couldn't see a way to actually set a timeout on existing requests, and it didn't look like restler had a default timeout.