### PR TITLE
Add support for fetching current users playlists

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -669,7 +669,9 @@ function SpotifyWebApi(credentials) {
 
   /**
    * Get a user's playlists.
-   * @param {string} userId The user ID.
+   * @param {string} userId An optional id of the user. If you know the Spotify URI it is easy
+   * to find the id (e.g. spotify:user:<here_is_the_id>). If not provided, the id of the user that granted
+   * the permissions will be used.
    * @param {Object} [options] The options supplied to this request.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
    * @example getUserPlaylists('thelinmichael').then(...)
@@ -677,8 +679,15 @@ function SpotifyWebApi(credentials) {
    *          a list of playlists. If rejected, it contains an error object. Not returned if a callback is given.
    */
   this.getUserPlaylists = function(userId, options, callback) {
+    var path;
+    if (typeof userId === 'string') {
+      path = '/v1/users/' + encodeURI(userId) + '/playlists';
+    } else {
+      path = '/v1/me/playlists';
+    }
+
     var request = WebApiRequest.builder()
-      .withPath('/v1/users/' + encodeURI(userId) + '/playlists')
+      .withPath(path)
       .build();
 
     _addAccessToken(request, this.getAccessToken());

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -993,6 +993,29 @@ describe('Spotify Web API', function() {
       });
   });
 
+  it('should get the current users playlists', function(done) {
+    sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
+      method.should.equal(restler.get);
+      uri.should.equal('https://api.spotify.com/v1/me/playlists');
+      should.not.exist(options.query);
+      callback(null, { body : { items: [
+        { uri: 'spotify:user:thelinmichael:playlist:5ieJqeLJjjI8iJWaxeBLuK' },
+        { uri: 'spotify:user:thelinmichael:playlist:3EsfV6XzCHU8SPNdbnFogK' }
+        ]},
+        statusCode : 200 });
+    });
+
+    var api = new SpotifyWebApi();
+    api.setAccessToken('myVeryLongAccessToken');
+
+    api.getUserPlaylists()
+      .then(function(data) {
+        (2).should.equal(data.body.items.length);
+        (200).should.equal(data.statusCode);
+        done();
+      });
+  });
+
   it('should get a playlist', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
       method.should.equal(restler.get);


### PR DESCRIPTION
This was previously proposed in this PR https://github.com/thelinmichael/spotify-web-api-node/pull/44. I think keeping the same signature as the client-side JS wrapper is a good idea.

@thelinmichael 