### PR TITLE
report spotify rate limit time back to client

### DIFF
--- a/src/webapi-rate-limit-error.js
+++ b/src/webapi-rate-limit-error.js
@@ -1,0 +1,12 @@
+'use strict';
+
+function WebapiRateLimitError(message, statusCode, retryAfter) {
+  this.name = 'WebapiRateLimitError';
+  this.message = (message || '');
+  this.statusCode = statusCode;
+  this.retryAfter = retryAfter;
+}
+
+WebapiRateLimitError.prototype = Error.prototype;
+
+module.exports = WebapiRateLimitError;


### PR DESCRIPTION
Issue: when spotify requests error with status 429 - rate limit exceeded the client does not receive any information on when the rate limit will be lifted.

Resolution: create a new error object for rate limited errors and report the number of seconds the client must wait before sending new requests.

I don't know if changing the name of the error object will cause issues in downstream code. Otherwise the error objects are api compatible. 