### PR TITLE
Fix reference to restler, now superagent

### DIFF
--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -995,7 +995,7 @@ describe('Spotify Web API', function() {
 
   it('should get the current users playlists', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
-      method.should.equal(restler.get);
+      method.should.equal(superagent.get);
       uri.should.equal('https://api.spotify.com/v1/me/playlists');
       should.not.exist(options.query);
       callback(null, { body : { items: [


### PR DESCRIPTION
This fixes a reference to restler, which should be now superagent.

@thelinmichael 