### PR TITLE
Make example explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,9 @@ Since the access token was set on the api object in the previous success callbac
 spotifyApi.refreshAccessToken()
   .then(function(data) {
     console.log('The access token has been refreshed!');
+    
+    // Save the access token so that it's used in future calls
+    spotifyApi.setAccessToken(data.body['access_token']);
   }, function(err) {
     console.log('Could not refresh access token', err);
   });


### PR DESCRIPTION
The refreshAccessToken call is not special; it kind of looked like it updates the access token in the spotifyApi object itself.
(at least, it looked like that to me for a second ;))