### PR TITLE
Add support for 'show_dialog' parameter when creating authorization url

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1256,19 +1256,22 @@ SpotifyWebApi.prototype = {
    * Retrieve a URL where the user can give the application permissions.
    * @param {string[]} scopes The scopes corresponding to the permissions the application needs.
    * @param {string} state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
+   * @param {boolean} showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
    * @returns {string} The URL where the user can give application permissions.
    */
   createAuthorizeURL: function(scopes, state, showDialog) {
+    var showDialogParam = showDialog ? { 'show_dialog' : showDialog } : null;
+    var options = {
+      'client_id' : this.getClientId(),
+      'response_type' : 'code',
+      'redirect_uri' : this.getRedirectURI(),
+      'scope' : scopes.join('%20'),
+      'state' : state
+    };
+    var actualOptions = Object.assign(options, showDialogParam);
     var request = AuthenticationRequest.builder()
       .withPath('/authorize')
-      .withQueryParameters({
-        'client_id' : this.getClientId(),
-        'response_type' : 'code',
-        'redirect_uri' : this.getRedirectURI(),
-        'scope' : scopes.join('%20'),
-        'state' : state,
-        'show_dialog' : showDialog
-      })
+      .withQueryParameters(actualOptions)
       .build();
 
     return request.getURL();

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1258,7 +1258,7 @@ SpotifyWebApi.prototype = {
    * @param {string} state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
    * @returns {string} The URL where the user can give application permissions.
    */
-  createAuthorizeURL: function(scopes, state) {
+  createAuthorizeURL: function(scopes, state, showDialog) {
     var request = AuthenticationRequest.builder()
       .withPath('/authorize')
       .withQueryParameters({
@@ -1266,7 +1266,8 @@ SpotifyWebApi.prototype = {
         'response_type' : 'code',
         'redirect_uri' : this.getRedirectURI(),
         'scope' : scopes.join('%20'),
-        'state' : state
+        'state' : state,
+        'show_dialog' : showDialog
       })
       .build();
 

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1325,15 +1325,16 @@ describe('Spotify Web API', function() {
     var scopes = ['user-read-private', 'user-read-email'],
         redirectUri = 'https://example.com/callback',
         clientId = '5fe01282e44241328a84e7c5cc169165',
-        state = 'some-state-of-my-choice';
+        state = 'some-state-of-my-choice',
+        showDialog = true;
 
     var api = new SpotifyWebApi({
         clientId : clientId,
         redirectUri : redirectUri
     });
 
-    var authorizeURL = api.createAuthorizeURL(scopes, state);
-    'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice'.should.equal(authorizeURL);
+    var authorizeURL = api.createAuthorizeURL(scopes, state, showDialog);
+    'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice&show_dialog=true'.should.equal(authorizeURL);
   });
 
   it('should set, get and reset credentials successfully', function() {

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1337,6 +1337,21 @@ describe('Spotify Web API', function() {
     'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice&show_dialog=true'.should.equal(authorizeURL);
   });
 
+  it('should ignore entire show_dialog param if it is not included', function() {
+    var scopes = ['user-read-private', 'user-read-email'],
+        redirectUri = 'https://example.com/callback',
+        clientId = '5fe01282e44241328a84e7c5cc169165',
+        state = 'some-state-of-my-choice';
+
+    var api = new SpotifyWebApi({
+        clientId : clientId,
+        redirectUri : redirectUri
+    });
+
+    var authorizeURL = api.createAuthorizeURL(scopes, state);
+    'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice'.should.equal(authorizeURL);
+  });
+
   it('should set, get and reset credentials successfully', function() {
     var api = new SpotifyWebApi({
       clientId : 'myClientId',


### PR DESCRIPTION
I needed to use the "show_dialog" parameter in my personal application to force users to approve the app each time they attempt to log in. This param is not currently supported by the wrapper -- for the time being I can create the auth url manually, but it was an easy addition so I added support for it here. 