### PR TITLE
Fix authorizationCodeGrant request parameters

### DIFF
--- a/src/server-methods.js
+++ b/src/server-methods.js
@@ -53,9 +53,10 @@ module.exports = {
       .withBodyParameters({
         'grant_type' : 'authorization_code',
         'redirect_uri' : this.getRedirectURI(),
-        'code' : code,
-        'client_id' : this.getClientId(),
-        'client_secret' : this.getClientSecret()
+        'code' : code
+      })
+      .withHeaders({
+        Authorization : ('Basic ' + new Buffer(this.getClientId() + ':' + this.getClientSecret()).toString('base64'))
       })
       .build();
 


### PR DESCRIPTION
Hey!

I fixed the authorizationCodeGrant method by putting the client_id and client_secret inside the Authorization HTTP header, as specified in the [documentation](https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow). 

I've seen some people running in the same issue and getting a 400 (Bad Request) error when trying to authenticate, I hope that helps.

Thanks for this great package btw!