### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ Some methods require authentication, which can be done using these flows:
 
 Even though authentication isn't always necessary, it always gives benefits such as an increased rate limit.
 
+<div style="margin: 25px;">
+<a href="https://rapidapi.com/package/SpotifyPublicAPI/functions?utm_source=SpotifyGitHub&utm_medium=button&utm_content=Vendor_GitHub" style="
+    all: initial;
+    background-color: #498FE1;
+    border-width: 0;
+    border-radius: 5px;
+    padding: 10px 20px;
+    color: white;
+    font-family: 'Helvetica';
+    font-size: 12pt;
+    background-image: url(https://scdn.rapidapi.com/logo-small.png);
+    background-size: 25px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 10px;
+    padding-left: 44px;
+    cursor: pointer;">
+  Test on <b>RapidAPI</b>
+</a>
+</div>
+
 ##### Dependencies
 
 This project depends on [superagent](https://github.com/visionmedia/superagent) to make HTTP requests, and [promise](https://github.com/then/promise) as its [Promises/A+](http://promises-aplus.github.io/promises-spec/) implementation.


### PR DESCRIPTION
Hey! I've added a link in your README to Spotify's functions page in RapidAPI. I've done this for a few Spotify SDKs to help those who are reading the READMEs, understand and test the API before use.