### PR TITLE
change addTracksToPlaylist to request body

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -921,17 +921,11 @@ SpotifyWebApi.prototype = {
    * it contains an error object. Not returned if a callback is given.
    */
   addTracksToPlaylist: function(userId, playlistId, tracks, options, callback) {
-    var tracksString;
-    if (typeof tracks === 'object') {
-      tracksString = tracks.join();
-    } else {
-      tracksString = tracks;
-    }
     var request = WebApiRequest.builder()
       .withPath('/v1/users/' + encodeURIComponent(userId) + '/playlists/' + playlistId + '/tracks')
       .withHeaders({ 'Content-Type' : 'application/json' })
       .withBodyParameters({
-        uris: tracksString
+        uris: tracks
       })
       .build();
 

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -930,7 +930,7 @@ SpotifyWebApi.prototype = {
     var request = WebApiRequest.builder()
       .withPath('/v1/users/' + encodeURIComponent(userId) + '/playlists/' + playlistId + '/tracks')
       .withHeaders({ 'Content-Type' : 'application/json' })
-      .withQueryParameters({
+      .withBodyParameters({
         uris: tracksString
       })
       .build();

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1134,7 +1134,8 @@ describe('Spotify Web API', function() {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
       method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
-      options.query.should.eql({uris: 'spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M'});
+      should.not.exist(options.query);
+      JSON.parse(options.data)["uris"].should.be.an.instanceOf(Array).and.have.lengthOf(2);
       callback(null, { body: { snapshot_id: 'aSnapshotId'}, statusCode : 201 });
     });
 
@@ -1151,10 +1152,11 @@ describe('Spotify Web API', function() {
   it('should add tracks to playlist with specified index', function(done) {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
       method.should.equal(superagent.post);
+      JSON.parse(options.data)["uris"].should.be.an.instanceOf(Array).and.have.lengthOf(2);
       options.query.should.eql({
-        uris: 'spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M',
         position: 10
       });
+      console.log('inside');
       callback(null, { body: { snapshot_id: 'aSnapshotId'}, statusCode : 201 });
     });
 
@@ -2042,9 +2044,8 @@ describe('Spotify Web API', function() {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
       method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
-      var trackUris = options.query.uris.split(",");
-      trackUris.should.be.an.instanceOf(Array).and.have.lengthOf(2);
-      should.not.exist(options.data);
+      should.not.exist(options.query);
+      JSON.parse(options.data)["uris"].should.be.an.instanceOf(Array).and.have.lengthOf(2);
       options.headers.Authorization.should.equal('Bearer long-access-token');
       callback();
     });
@@ -2066,9 +2067,8 @@ describe('Spotify Web API', function() {
     sinon.stub(HttpManager, '_makeRequest', function(method, options, uri, callback) {
       method.should.equal(superagent.post);
       uri.should.equal('https://api.spotify.com/v1/users/thelinmichael/playlists/5ieJqeLJjjI8iJWaxeBLuK/tracks');
-      var trackUris = options.query.uris.split(",");
-      trackUris.should.be.an.instanceOf(Array).and.have.lengthOf(2);
-      should.not.exist(options.data);
+      should.not.exist(options.query);
+      JSON.parse(options.data)["uris"].should.be.an.instanceOf(Array).and.have.lengthOf(2);
       options.headers.Authorization.should.equal('Bearer long-access-token');
       callback();
     });

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1156,7 +1156,6 @@ describe('Spotify Web API', function() {
       options.query.should.eql({
         position: 10
       });
-      console.log('inside');
       callback(null, { body: { snapshot_id: 'aSnapshotId'}, statusCode : 201 });
     });
 


### PR DESCRIPTION
According to the following note:

"Note: it is likely that passing a large number of track URIs as a query parameter will exceed the maximum length of the request URI. When adding a large number of tracks it is recommended to pass them in the request body, see below."
https://developer.spotify.com/web-api/add-tracks-to-playlist/

just changed withQueryParameters to withBodyParameters in addTracksToPlaylist