### PR TITLE
Rename to getMyRecentlyPlayedTracks

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1570,7 +1570,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  getMyRecentlyPlayed: function(options, callback) {
+  getMyRecentlyPlayedTracks: function(options, callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/recently-played')
       .build();

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1242,7 +1242,7 @@ describe('Spotify Web API', function() {
       accessToken : 'someAccessToken'
     });
 
-    api.getMyRecentlyPlayed({ limit : 5})
+    api.getMyRecentlyPlayedTracks({ limit : 5})
       .then(function(data) {
         should.exist(data.body.items);
         done();


### PR DESCRIPTION
Renaming `getMyRecentlyPlayed` to `getMyRecentlyPlayedTracks` to be more consistent with the rest of functions and the same method in [the client-side JS wrapper](https://github.com/JMPerez/spotify-web-api-js).