### PR TITLE
Unify method names with those from client-side JS wrapper

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1623,7 +1623,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  getMyCurrentlyPlaying: function(options, callback) {
+  getMyCurrentPlayingTrack: function(options, callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/currently-playing')
       .build();
@@ -1706,14 +1706,14 @@ SpotifyWebApi.prototype = {
   },
 
   /**
-   * Resumes the Current User's Playback
+   * Starts o Resumes the Current User's Playback
    * @param {Object} [options] Options, being context_uri, offset, uris.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
    * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  playbackResume: function(options, callback) {
+  play: function(options, callback) {
 
     var actualOptions = {};
     if (typeof options === 'object') {
@@ -1750,7 +1750,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  playbackPause: function(callback) {
+  pause: function(callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/pause')
       .build();
@@ -1777,7 +1777,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  playbackPrevious: function(callback) {
+  skipToPrevious: function(callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/previous')
       .build();
@@ -1804,7 +1804,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  playbackNext: function(callback) {
+  skipToNext: function(callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/next')
       .build();
@@ -1832,7 +1832,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  playbackRepeat: function(options, callback) {
+  setRepeat: function(options, callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/repeat')
       .withQueryParameters({
@@ -1863,7 +1863,7 @@ SpotifyWebApi.prototype = {
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  playbackShuffle: function(options, callback) {
+  setShuffle: function(options, callback) {
     var request = WebApiRequest.builder()
       .withPath('/v1/me/player/shuffle')
       .withQueryParameters({

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1347,7 +1347,7 @@ describe('Spotify Web API', function() {
       accessToken : accessToken
     });
 
-    api.playbackResume()
+    api.play()
       .then(function(data) {
         done();
       }, function(err) {
@@ -1372,7 +1372,7 @@ describe('Spotify Web API', function() {
       accessToken : accessToken
     });
 
-    api.playbackPause()
+    api.pause()
       .then(function(data) {
         done();
       }, function(err) {
@@ -1397,7 +1397,7 @@ describe('Spotify Web API', function() {
       accessToken : accessToken
     });
 
-    api.playbackNext()
+    api.skipToNext()
       .then(function(data) {
         done();
       }, function(err) {
@@ -1422,7 +1422,7 @@ describe('Spotify Web API', function() {
       accessToken : accessToken
     });
 
-    api.playbackPrevious()
+    api.skipToPrevious()
       .then(function(data) {
         done();
       }, function(err) {
@@ -1448,7 +1448,7 @@ describe('Spotify Web API', function() {
       accessToken : accessToken
     });
 
-    api.playbackRepeat({state: 'off'})
+    api.setRepeat({state: 'off'})
       .then(function(data) {
         done();
       }, function(err) {
@@ -1474,7 +1474,7 @@ describe('Spotify Web API', function() {
       accessToken : accessToken
     });
 
-    api.playbackShuffle({state: 'false'})
+    api.setShuffle({state: 'false'})
       .then(function(data) {
         done();
       }, function(err) {


### PR DESCRIPTION
This PR sets the same method names than the ones used in https://github.com/JMPerez/spotify-web-api-js. This facilitates porting code from client-side to server-side and will make it easier to build an isomorphic library eventually.