### PR TITLE
Removes unnecessary deviceIds parameter from request to transfer playback

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1689,6 +1689,7 @@ SpotifyWebApi.prototype = {
       })
       .build();
 
+    delete options.deviceIds;
     this._addAccessToken(request, this.getAccessToken());
     this._addBodyParameters(request, options);
 

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1306,8 +1306,7 @@ describe('Spotify Web API', function() {
       uri.should.equal('https://api.spotify.com/v1/me/player');
       JSON.parse(options.data).should.eql({
         'device_ids': ['deviceId'],
-        'play': true,
-        'deviceIds' : ['deviceId']
+        'play': true
       });
       should.not.exist(options.query);
       callback();


### PR DESCRIPTION
As pointed out by @brodin, [the extra `deviceIds` in the options is unnecessary](https://github.com/thelinmichael/spotify-web-api-node/pull/121/files/a38a35932ea28689b16830769b556c3f46d6b31d#r136781034).