### PR TITLE
Create authorization urls for Implicit Grant flow

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -798,14 +798,15 @@ SpotifyWebApi.prototype = {
    * @param {string[]} scopes The scopes corresponding to the permissions the application needs.
    * @param {string} state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
    * @param {boolean} showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
+   * @param {boolean} isImplicit A parameter that specifies creating a URL for implicit grant flow.
    * @returns {string} The URL where the user can give application permissions.
    */
-  createAuthorizeURL: function(scopes, state, showDialog) {
+  createAuthorizeURL: function(scopes, state, showDialog, isImplicit) {
     return AuthenticationRequest.builder()
       .withPath('/authorize')
       .withQueryParameters({
         'client_id' : this.getClientId(),
-        'response_type' : 'code',
+        'response_type' : isImplicit && !!isImplicit ? 'token' : 'code',
         'redirect_uri' : this.getRedirectURI(),
         'scope' : scopes.join('%20'),
         'state' : state,

--- a/test/spotify-web-api.js
+++ b/test/spotify-web-api.js
@@ -1597,6 +1597,21 @@ describe('Spotify Web API', function() {
     'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice&show_dialog=true'.should.equal(authorizeURL);
   });
 
+  it('should create authorization URL for implicit grant flow', function() {
+        var scopes = ['user-read-private', 'user-read-email'],
+      redirectUri = 'https://example.com/callback',
+      clientId = '5fe01282e44241328a84e7c5cc169165',
+      state = 'some-state-of-my-choice',
+      showDialog = true
+      isImplicit = true;
+
+    var api = new SpotifyWebApi({
+      clientId: clientId,
+      redirectUri: redirectUri
+    });
+    var authorizeURL = api.createAuthorizeURL(scopes, state, showDialog, isImplicit);
+    authorizeURL.should.equal('https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=token&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice&show_dialog=true');
+  })
   it('should ignore entire show_dialog param if it is not included', function() {
     var scopes = ['user-read-private', 'user-read-email'],
         redirectUri = 'https://example.com/callback',


### PR DESCRIPTION
This adds support for creating authorization URLs for [Implicit Grant flow](https://developer.spotify.com/web-api/authorization-guide/#implicit-grant-flow) via an extra parameter in `createAuthorizeURL`.

This parameter just changes the URL's `response_type` to `token` rather than `code`.