### PR TITLE
Added device_id option to accomodate query parameters

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1065,7 +1065,7 @@ SpotifyWebApi.prototype = {
    */
   play: function(options, callback) {
     return WebApiRequest.builder(this.getAccessToken())
-      .withPath(options.device_id ? '/v1/me/player/play?device_id=' + options.device_id : '/v1/me/player/play')
+      .withPath(options.deviceId ? '/v1/me/player/play?device_id=' + options.deviceId : '/v1/me/player/play')
       .withHeaders({ 'Content-Type' : 'application/json' })
       .withBodyParameters(options)
       .build()

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1065,7 +1065,7 @@ SpotifyWebApi.prototype = {
    */
   play: function(options, callback) {
     return WebApiRequest.builder(this.getAccessToken())
-      .withPath('/v1/me/player/play')
+      .withPath(options.device_id ? '/v1/me/player/play?device_id=' + options.device_id : '/v1/me/player/play')
       .withHeaders({ 'Content-Type' : 'application/json' })
       .withBodyParameters(options)
       .build()


### PR DESCRIPTION
Added device_id option to accomodate query parameters to target a specific device.
This is missing in comparison to the native spotify play api and will allow the device_id query parameters to be specified with options.

Source:
https://developer.spotify.com/web-api/start-a-users-playback/