### PR TITLE
Volume and seek methods for user UPDATE

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1086,7 +1086,7 @@ SpotifyWebApi.prototype = {
   volume: function(volume, options, callback) {
     /*jshint camelcase: false */
     var _options = options || {};
-    var queryParams = _options.device_id ? {device_id: _options.device_id} : null;
+    var queryParams = _options.device_id ? {device_id: _options.device_id} : {};
     queryParams.volume_percent = volume;
     return WebApiRequest.builder(this.getAccessToken())
       .withPath('/v1/me/player/volume')
@@ -1108,7 +1108,7 @@ SpotifyWebApi.prototype = {
   seek: function(position, options, callback) {
     /*jshint camelcase: false */
     var _options = options || {};
-    var queryParams = _options.device_id ? {device_id: _options.device_id} : null;
+    var queryParams = _options.device_id ? {device_id: _options.device_id} : {};
     queryParams.position_ms = position;
     return WebApiRequest.builder(this.getAccessToken())
       .withPath('/v1/me/player/seek')

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1084,6 +1084,7 @@ SpotifyWebApi.prototype = {
     *          otherwise an error. Not returned if a callback is given.
     */
   volume: function(volume, options, callback) {
+    /*jshint camelcase: false */
     var _options = options || {};
     var queryParams = _options.device_id ? {device_id: _options.device_id} : null;
     queryParams.volume_percent = volume;
@@ -1092,7 +1093,7 @@ SpotifyWebApi.prototype = {
       .withHeaders({ 'Content-Type' : 'application/json' })
       .withQueryParameters(queryParams)
       .build()
-      .execute(HttpManager.put, actualCallback);
+      .execute(HttpManager.put, callback);
   },
 
    /**
@@ -1105,6 +1106,7 @@ SpotifyWebApi.prototype = {
    *          otherwise an error. Not returned if a callback is given.
    */
   seek: function(position, options, callback) {
+    /*jshint camelcase: false */
     var _options = options || {};
     var queryParams = _options.device_id ? {device_id: _options.device_id} : null;
     queryParams.position_ms = position;

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1075,6 +1075,44 @@ SpotifyWebApi.prototype = {
   },
 
   /**
+   * Set volume of the Current User's Playback
+   * @param {int} volume percentage 0 - 100
+   * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+   * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
+   * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+   *          otherwise an error. Not returned if a callback is given.
+   */
+  volume: function(volume, callback) {
+    return WebApiRequest.builder(this.getAccessToken())
+      .withPath('/v1/me/player/volume')
+      .withHeaders({ 'Content-Type' : 'application/json' })
+      .withQueryParameters({
+        'volume_percent': volume
+      })
+      .build()
+      .execute(HttpManager.put, callback);
+  },
+
+   /**
+   * Set seek poistion (ms) of the Current User's Playback
+   * @param {int} Position (ms) to seek
+   * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+   * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
+   * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+   *          otherwise an error. Not returned if a callback is given.
+   */
+  seek: function(position, callback) {
+    return WebApiRequest.builder(this.getAccessToken())
+      .withPath('/v1/me/player/seek')
+      .withHeaders({ 'Content-Type' : 'application/json' })
+      .withQueryParameters({
+        'position_ms': position
+      })
+      .build()
+      .execute(HttpManager.put, callback);
+  },
+
+  /**
    * Starts o Resumes the Current User's Playback
    * @param {Object} [options] Options, being device_id, context_uri, offset, uris.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1074,40 +1074,44 @@ SpotifyWebApi.prototype = {
       .execute(HttpManager.put, callback);
   },
 
-  /**
-   * Set volume of the Current User's Playback
-   * @param {int} volume percentage 0 - 100
-   * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-   * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
-   * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
-   *          otherwise an error. Not returned if a callback is given.
-   */
-  volume: function(volume, callback) {
+   /**
+    * Set volume of the Current User's Playback
+    * @param {int} volume percentage 0 - 100
+    * @param {Object} [options] Options, being device ID
+    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+    * @example volume(50).then(...)
+    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+    *          otherwise an error. Not returned if a callback is given.
+    */
+  volume: function(volume, options, callback) {
+    var _options = options || {};
+    var queryParams = _options.device_id ? {device_id: _options.device_id} : null;
+    queryParams.volume_percent = volume;
     return WebApiRequest.builder(this.getAccessToken())
       .withPath('/v1/me/player/volume')
       .withHeaders({ 'Content-Type' : 'application/json' })
-      .withQueryParameters({
-        'volume_percent': volume
-      })
+      .withQueryParameters(queryParams)
       .build()
-      .execute(HttpManager.put, callback);
+      .execute(HttpManager.put, actualCallback);
   },
 
    /**
    * Set seek poistion (ms) of the Current User's Playback
    * @param {int} Position (ms) to seek
+   * @param {Object} [options] Options, being device ID
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-   * @example playbackResume({context_uri: 'spotify:album:5ht7ItJgpBH7W6vJ5BqpPr'}).then(...)
+   * @example seek(5000).then(...)
    * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
    *          otherwise an error. Not returned if a callback is given.
    */
-  seek: function(position, callback) {
+  seek: function(position, options, callback) {
+    var _options = options || {};
+    var queryParams = _options.device_id ? {device_id: _options.device_id} : null;
+    queryParams.position_ms = position;
     return WebApiRequest.builder(this.getAccessToken())
       .withPath('/v1/me/player/seek')
       .withHeaders({ 'Content-Type' : 'application/json' })
-      .withQueryParameters({
-        'position_ms': position
-      })
+      .withQueryParameters(queryParams)
       .build()
       .execute(HttpManager.put, callback);
   },


### PR DESCRIPTION
It didn't look like anything was happening with the [volume and seek method PR created by vanderlin](https://github.com/thelinmichael/spotify-web-api-node/pull/156) so I've added the optional device_id as requested.

Also rebased on current master.

@vanderlin @JMPerez @thelinmichael 