### PR TITLE
Add support for self-invoking constructor

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -5,6 +5,10 @@ var AuthenticationRequest = require('./authentication-request'),
     HttpManager = require('./http-manager');
 
 function SpotifyWebApi(credentials) {
+  if (!(this instanceof SpotifyWebApi)) {
+    return new SpotifyWebApi(credentials);
+  }
+
   this._credentials = credentials || {};
 }
 


### PR DESCRIPTION
useful to omit `new` when creating instance:

```js
const spotifyApi = SpotifyWebApi({
    cliendId: config.spotify.cliendId,
    clientSecret: config.spotify.clientSecret,
    redirectUri: config.spotify.redirectUri
});
```