### PR TITLE
Add personalization endpoint methods to reference list

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,10 +712,24 @@ spotifyApi.getMyCurrentPlaybackState({
  */
 
 /* Get a User’s Top Artists and Tracks */
-// TBD
 
-Get a User’s Top Artists and Tracks
-```
+/// Get a User’s Top Artists
+spotifyApi.getMyTopArtists({})
+  .then(function(data) {
+    // Output items
+    console.log("Top Artist: ", data.body.items[0].name);
+  }, function(err) {
+    console.log("Something went wrong!", err);
+  });
+  
+// Get a User's Top Tracks
+spotifyApi.getMyTopTracks({})
+  .then(function(data) {
+    // Output items
+    console.log("Top Track: ", data.body.items[0].name);
+  }, function(err) {
+    console.log("Something went wrong!", err);
+  });
 
 ### Nesting calls
 


### PR DESCRIPTION
I noticed that README.md was lacking the personalization endpoints despite the methods existing. Just wanted to update the list just in case it helps, so I added the getMyTopArtists and getMyTopTracks methods with an example of how to target the data.