### PR TITLE
include original request url in error object for web api errors

### DIFF
--- a/__tests__/http-manager.js
+++ b/__tests__/http-manager.js
@@ -27,7 +27,15 @@ describe('Make requests', () => {
     });
 
     test('Should process an error GET request', done => {
-      superagent.__setMockError(new Error('GET request error'));
+      superagent.__setMockError({
+        name: 'Error',
+        message: 'GET request error',
+        response: {
+          request: {
+            url: 'https://api.spotify.com'
+          }
+        }
+      });
 
       var HttpManager = require('../src/http-manager');
       var request = Request.builder()
@@ -44,9 +52,15 @@ describe('Make requests', () => {
     });
 
     test('Should process an error GET request with an error message', done => {
-      superagent.__setMockError(
-        new Error('There is a problem in your request')
-      );
+      superagent.__setMockError({
+        name: 'Error',
+        message: 'There is a problem in your request',
+        response: {
+          request: {
+            url: 'https://api.spotify.com'
+          }
+        }
+      });
 
       var HttpManager = require('../src/http-manager');
       var request = Request.builder()

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   ],
   "browser": {
     "./src/server.js": "./src/client.js"
+  },
+  "jest": {
+    "testURL": "http://localhost/"
   }
 }

--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -33,7 +33,7 @@ var _getErrorObject = function(defaultMessage, err) {
   var errorObject;
   if (typeof err.error === 'object' && typeof err.error.message === 'string') {
     // Web API Error format
-    errorObject = new WebApiError(err.error.message, err.error.status);
+    errorObject = new WebApiError(err.error.message, err.error.status, err.error.response.request.url);
   } else if (typeof err.error === 'string') {
     // Authorization Error format
     /* jshint ignore:start */

--- a/src/webapi-error.js
+++ b/src/webapi-error.js
@@ -1,9 +1,10 @@
 'use strict';
 
-function WebapiError(message, statusCode) {
+function WebapiError(message, statusCode, request) {
   this.name = 'WebapiError';
   this.message = message || '';
   this.statusCode = statusCode;
+  this.request = request || '';
 }
 
 WebapiError.prototype = Error.prototype;


### PR DESCRIPTION
Helpful for cases of managing request state using message queues.