### PR TITLE
Added userID paramater to createPlaylist documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ spotifyApi.getUserPlaylists('thelinmichael')
   });
 
 // Create a private playlist
-spotifyApi.createPlaylist('My Cool Playlist', { 'public' : false })
+spotifyApi.createPlaylist('userID', 'My Cool Playlist', { 'public' : false })
   .then(function(data) {
     console.log('Created playlist!');
   }, function(err) {


### PR DESCRIPTION
The README for `createPlaylist` was missing the userID paramater