### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ spotifyApi.getUserPlaylists('thelinmichael')
   });
 
 // Create a private playlist
-spotifyApi.createPlaylist('My Cool Playlist', { 'public' : false })
+spotifyApi.createPlaylist('thelinmichael', 'My Cool Playlist', { 'public' : false })
   .then(function(data) {
     console.log('Created playlist!');
   }, function(err) {

--- a/examples/add-remove-replace-tracks-in-a-playlist.js
+++ b/examples/add-remove-replace-tracks-in-a-playlist.js
@@ -48,7 +48,7 @@ spotifyApi
     playlistId = data.body['id'];
 
     // Add tracks to the playlist
-    return spotifyApi.addTracksToPlaylist('thelinmichael', playlistId, [
+    return spotifyApi.addTracksToPlaylist(playlistId, [
       'spotify:track:4iV5W9uYEdYUVa79Axb7Rh',
       'spotify:track:6tcfwoGcDjxnSc6etAkDRR',
       'spotify:track:4iV5W9uYEdYUVa79Axb7Rh'

--- a/examples/add-tracks-to-a-playlist.js
+++ b/examples/add-tracks-to-a-playlist.js
@@ -32,7 +32,6 @@ spotifyApi
   .then(function(data) {
     spotifyApi.setAccessToken(data.body['access_token']);
     return spotifyApi.addTracksToPlaylist(
-      'thelinmichael',
       '5ieJqeLJjjI8iJWaxeBLuK',
       [
         'spotify:track:4iV5W9uYEdYUVa79Axb7Rh',

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -615,7 +615,7 @@ SpotifyWebApi.prototype = {
    * @param {string[]} tracks URIs of the tracks to add to the playlist.
    * @param {Object} [options] Options, position being the only one.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
-   * @example addTracksToPlaylist('thelinmichael', '3EsfV6XzCHU8SPNdbnFogK',
+   * @example addTracksToPlaylist('3EsfV6XzCHU8SPNdbnFogK',
               '["spotify:track:4iV5W9uYEdYUVa79Axb7Rh", "spotify:track:1301WleyT98MSxVHPZCA6M"]').then(...)
    * @returns {Promise|undefined} A promise that if successful returns an object containing a snapshot_id. If rejected,
    * it contains an error object. Not returned if a callback is given.


### PR DESCRIPTION
The arguments being passed to `createPlaylist` and `addTracksToPlaylist` in the examples are not up to date with the code. I discovered this because I was getting 404s when trying the examples.
