### PR TITLE
Add support for detailed Spotify Web API error message and reason

### DIFF
--- a/__tests__/http-manager.js
+++ b/__tests__/http-manager.js
@@ -1,5 +1,6 @@
 var Request = require('../src/base-request');
 var superagent = require('superagent');
+var WebApiError = require('../src/webapi-error');
 
 describe('Make requests', () => {
   afterEach(() => {
@@ -58,6 +59,35 @@ describe('Make requests', () => {
       HttpManager.get(request, function(errorObject) {
         expect(errorObject).toBeInstanceOf(Error);
         expect(errorObject.message).toBe('There is a problem in your request');
+        done();
+      });
+    });
+
+    test('Should process an error GET request with an error reason when detailed Web API error object is in response', done => {
+      superagent.__setMockError({
+        message: 'Generic Error Message',
+        response: {
+          body: {
+            error: {
+              message: 'Detailed Web API Error message',
+              status: 400,
+              reason: 'You messed up!'
+            }
+          }
+        }
+      });
+
+      var HttpManager = require('../src/http-manager');
+      var request = Request.builder()
+        .withHost('such.api.wow')
+        .withPort(1337)
+        .withScheme('http')
+        .build();
+
+      HttpManager.get(request, function(errorObject) {
+        expect(errorObject).toBeInstanceOf(Error);
+        expect(errorObject.message).toBe('Detailed Web API Error message');
+        expect(errorObject.reason).toBe('You messed up!');
         done();
       });
     });

--- a/__tests__/webapi-error.js
+++ b/__tests__/webapi-error.js
@@ -6,4 +6,15 @@ describe('Create Web Api Error', () => {
     expect(error.message).toBe('Something has gone terribly wrong!');
     expect(error.statusCode).toBe(500);
   });
+
+  test('should create error with message, status code and reason if reason is provided', () => {
+    var error = new WebApiError(
+      'Something has gone terribly wrong!',
+      500,
+      'You messed up!'
+    );
+    expect(error.message).toBe('Something has gone terribly wrong!');
+    expect(error.reason).toBe('You messed up!');
+    expect(error.statusCode).toBe(500);
+  });
 });

--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -33,7 +33,6 @@ var _getErrorObject = function(defaultMessage, err) {
   var errorObject;
   if (typeof err.error === 'object' && typeof err.error.message === 'string') {
     // Web API Error format
-    console.log(err.error);
     var webApiErrorObject = err.error.response && err.error.response.body;
     // Use detailed Web API error object only if message and status exist
     // reason can be undefined, we still benefit from a more detailed error message

--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -33,7 +33,24 @@ var _getErrorObject = function(defaultMessage, err) {
   var errorObject;
   if (typeof err.error === 'object' && typeof err.error.message === 'string') {
     // Web API Error format
-    errorObject = new WebApiError(err.error.message, err.error.status);
+    console.log(err.error);
+    var webApiErrorObject = err.error.response && err.error.response.body;
+    // Use detailed Web API error object only if message and status exist
+    // reason can be undefined, we still benefit from a more detailed error message
+    if (
+      webApiErrorObject &&
+      webApiErrorObject.error &&
+      webApiErrorObject.error.message &&
+      webApiErrorObject.error.status
+    ) {
+      errorObject = new WebApiError(
+        webApiErrorObject.error.message,
+        webApiErrorObject.error.status,
+        webApiErrorObject.error.reason
+      );
+    } else {
+      errorObject = new WebApiError(err.error.message, err.error.status);
+    }
   } else if (typeof err.error === 'string') {
     // Authorization Error format
     /* jshint ignore:start */

--- a/src/webapi-error.js
+++ b/src/webapi-error.js
@@ -1,9 +1,12 @@
 'use strict';
 
-function WebapiError(message, statusCode) {
+function WebapiError(message, statusCode, reason) {
   this.name = 'WebapiError';
   this.message = message || '';
   this.statusCode = statusCode;
+  if (reason) {
+    this.reason = reason;
+  }
 }
 
 WebapiError.prototype = Error.prototype;


### PR DESCRIPTION
Fixes #286 

When a request produces an error the Spotify Web API includes a [error object](https://developer.spotify.com/documentation/web-api/reference/object-model/#error-object) in the response. If the request was against a [player endpoint](https://developer.spotify.com/documentation/web-api/reference/player/), this [player error object](https://developer.spotify.com/documentation/web-api/reference/object-model/#player-error-object) will also include a reason string.

The current implementation uses neither of those error objects. Instead the error message will be generic based on the HTTP status code (e.g. `Bad Request` for 400, `Bad Gateway` for 502). Having access to these detail-rich error responses is important for debugging. In the case of the player error responses, it is also unlocks the ability to react to different error reasons. In my case, I needed to differentiate between different reasons for a 403 errors.