### PR TITLE
Fixed refreshAccessToken() unauthorized error

### DIFF
--- a/src/server-methods.js
+++ b/src/server-methods.js
@@ -65,8 +65,8 @@ module.exports = {
     return AuthenticationRequest.builder()
       .withPath('/api/token')
       .withBodyParameters({
-        grant_type: 'refresh_token',
-        refresh_token: this.getRefreshToken()
+        grant_type: 'client_credentials',
+        code: this.getRefreshToken()
       })
       .withHeaders({
         Authorization:


### PR DESCRIPTION
```
Error refreshing token { [WebapiError: Bad Request] name: 'WebapiError', message: 'Bad Request', statusCode: 400 }
```

Updated per new authorization flow
https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow