### PR TITLE
transferMyPlayback not working

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1081,7 +1081,7 @@ SpotifyWebApi.prototype = {
       .withPath('/v1/me/player')
       .withHeaders({ 'Content-Type': 'application/json' })
       .withBodyParameters({
-        device_ids: options.deviceIds,
+        device_ids: options.device_ids,
         play: !!options.play
       })
       .build()


### PR DESCRIPTION
According to the type definition of the TransferPlaybackOptions one of the arguments is called device_ids, but in the implementation the argument is called deviceIds. So changed the function transferMyPlayback so that the argument is called device_ids too.