### PR TITLE
Fix documentation example for getPlaylistTracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ var spotifyApi = new SpotifyWebApi({
 
 // Get tracks in a playlist
 api
-  .getPlaylistTracks('thelinmichael', '3ktAYNcRHpazJ9qecm3ptn', {
+  .getPlaylistTracks('3ktAYNcRHpazJ9qecm3ptn', {
     offset: 1,
     limit: 5,
     fields: 'items'


### PR DESCRIPTION
As noted in the [release notes for v4.0.0](https://github.com/thelinmichael/spotify-web-api-node/releases/tag/v4.0.0), functions that operate on playlists do not need the user ID parameter, and as I tested `getPlaylistTracks` is one of them.

I updated the example in the README.