### PR TITLE
Update `createAuthorizeURL` to support `token` response types

### DIFF
--- a/__tests__/spotify-web-api.js
+++ b/__tests__/spotify-web-api.js
@@ -2358,7 +2358,7 @@ describe('Spotify Web API', () => {
     });
   });
 
-  test('should create authorization URL', () => {
+  test('should create authorization URL with code based authentication', () => {
     var scopes = ['user-read-private', 'user-read-email'],
       redirectUri = 'https://example.com/callback',
       clientId = '5fe01282e44241328a84e7c5cc169165',
@@ -2373,6 +2373,25 @@ describe('Spotify Web API', () => {
     var authorizeURL = api.createAuthorizeURL(scopes, state, showDialog);
     expect(authorizeURL).toBe(
       'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=code&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice&show_dialog=true'
+    );
+  });
+
+  test('should create authorization URL with token based authentication', () => {
+    var scopes = ['user-read-private', 'user-read-email'],
+      redirectUri = 'https://example.com/callback',
+      clientId = '5fe01282e44241328a84e7c5cc169165',
+      state = 'some-state-of-my-choice',
+      showDialog = true,
+      responseType = 'token'
+
+    var api = new SpotifyWebApi({
+      clientId: clientId,
+      redirectUri: redirectUri
+    });
+
+    var authorizeURL = api.createAuthorizeURL(scopes, state, showDialog, responseType);
+    expect(authorizeURL).toBe(
+      'https://accounts.spotify.com/authorize?client_id=5fe01282e44241328a84e7c5cc169165&response_type=token&redirect_uri=https://example.com/callback&scope=user-read-private%20user-read-email&state=some-state-of-my-choice&show_dialog=true'
     );
   });
 

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -834,14 +834,15 @@ SpotifyWebApi.prototype = {
    * @param {string[]} scopes The scopes corresponding to the permissions the application needs.
    * @param {string} state A parameter that you can use to maintain a value between the request and the callback to redirect_uri.It is useful to prevent CSRF exploits.
    * @param {boolean} showDialog A parameter that you can use to force the user to approve the app on each login rather than being automatically redirected.
+   * @param {string} showDialog A parameter that you can use to specify the code response based on the authentication type - can be set to 'code' or 'token'.
    * @returns {string} The URL where the user can give application permissions.
    */
-  createAuthorizeURL: function(scopes, state, showDialog) {
+  createAuthorizeURL: function(scopes, state, showDialog, responseType = 'code') {
     return AuthenticationRequest.builder()
       .withPath('/authorize')
       .withQueryParameters({
         client_id: this.getClientId(),
-        response_type: 'code',
+        response_type: responseType,
         redirect_uri: this.getRedirectURI(),
         scope: scopes.join('%20'),
         state: state,


### PR DESCRIPTION
Added support for token based authentication as documented on Spotify's [authorization guide](https://developer.spotify.com/documentation/general/guides/authorization-guide/).