### PR TITLE
Fix error handling in http-manager #340

### DIFF
--- a/__tests__/http-manager.js
+++ b/__tests__/http-manager.js
@@ -209,5 +209,13 @@ describe('Make requests', () => {
     });
   });
 
+  test('Should handle arbitrary exceptions', done => {
+    superagent.__setMockError(new Error('ops'));
+
+    HttpManager.get(request, function(error) {
+      expect(error).toBeInstanceOf(Error);
+      done();
+    });
+  });
 });
 

--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -67,8 +67,10 @@ HttpManager._makeRequest = function(method, options, uri, callback) {
     if (err) {
       if (err.timeout) {
         return callback(new TimeoutError());
-      } else {
+      } else if (err.response) {
         return callback(_toError(err.response));
+      } else {
+        return callback(err);
       }
     }
 


### PR DESCRIPTION
This would crash previously if there was a superagent error without a response. Unknown errors will now be forwarded if there's no `error.response`.