### PR TITLE
Add getGeneric function; Add to tutorials

### DIFF
--- a/examples/tutorial/01-basics/02-get-all-playlists-of-me.js
+++ b/examples/tutorial/01-basics/02-get-all-playlists-of-me.js
@@ -1,0 +1,26 @@
+const SpotifyWebApi = require('../../../');
+
+const spotifyApi = new SpotifyWebApi();
+spotifyApi.setAccessToken(process.env.SPOTIFY_ACCESS_TOKEN);
+
+(async () => {
+  // Get first batch of playlists
+  const playlist = await spotifyApi.getUserPlaylists();
+  const allItems = [...playlist.body.items];
+
+  // Get further paging objects
+  let next = playlist.body.next;
+  while(next) {
+    const nextItems = await spotifyApi.getGeneric(next);
+    next = nextItems.body.next;
+
+    allItems.push(...nextItems.body.items);
+  }
+
+  // Display data
+  let playlistNames = allItems.map(p => p.name);
+  console.log(playlistNames);
+
+})().catch(e => {
+  console.error(e);
+});

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -1649,6 +1649,19 @@ SpotifyWebApi.prototype = {
       .build()
       .execute(HttpManager.get, callback);
   },
+
+  /**
+   * Retrieve generic URL by a GET request. This can be used to process the body.next parameter of a response.
+   * @param {string} url URL from which information is to be retrieved.
+   * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+   * @returns {Promise|undefined}
+   */
+  getGeneric: function(url, callback) {
+    return WebApiRequest.builder(this.getAccessToken())
+      .withPath(url.replace(/^https:\/\/api.spotify.com/, ''))
+      .build()
+      .execute(HttpManager.get, callback);
+  },
 };
 
 SpotifyWebApi._addMethods = function(methods) {


### PR DESCRIPTION
How do you feel about a function like this?
```javascript
spotifyApi.getGeneric('https://api.spotify.com/v1/users/USERID/playlists?offset=20&limit=20')
```

It would make things like this possible (see tutorial folder for working example):

```javascript
// Get first batch of playlists
const playlist = await spotifyApi.getUserPlaylists();
const allItems = [...playlist.body.items];

// Get further paging objects
let next = playlist.body.next;
while(next) {
  const nextItems = await spotifyApi.getGeneric(next);
  next = nextItems.body.next;

  allItems.push(...nextItems.body.items);
}
```