### PR TITLE
Deprecation Warning use new Buffer() → Buffer.from()

### DIFF
--- a/src/server-methods.js
+++ b/src/server-methods.js
@@ -44,7 +44,7 @@ module.exports = {
       .withHeaders({
         Authorization:
           'Basic ' +
-          new Buffer(
+          Buffer.from(
             this.getClientId() + ':' + this.getClientSecret()
           ).toString('base64'),
         'Content-Type' : 'application/x-www-form-urlencoded'        
@@ -95,7 +95,7 @@ module.exports = {
       .withHeaders({
         Authorization:
           'Basic ' +
-          new Buffer(
+          Buffer.from(
             this.getClientId() + ':' + this.getClientSecret()
           ).toString('base64'),
           'Content-Type' : 'application/x-www-form-urlencoded'


### PR DESCRIPTION
When using for e.g. `spotifyApi.refreshAccessToken();` (which uses [`new Buffer()`](https://github.com/thelinmichael/spotify-web-api-node/blob/be15f1c742b35134ce5bd35521d8bf1ab1ba67cf/src/server-methods.js#L98)):
```
(node:79216) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

From what I found [here](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) this will however drop support for Node.js ≤ 5.9.x.