### PR TITLE
Added support for get user's queue endpoint + added 'addToQueue' example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,6 +787,16 @@ spotifyApi.getAvailableGenreSeeds()
 // Add an Item to the User's Playback Queue
 // TBD
 
+
+// Get a User's Queue
+spotifyApi.getMyQueue()
+  .then(function(data) {
+    let queue = data.body.queue;
+    console.log(queue);
+  }, function(err) {
+    console.log('Something went wrong!', err);
+  })
+
 // Get a User's Available Devices
 spotifyApi.getMyDevices()
   .then(function(data) {

--- a/README.md
+++ b/README.md
@@ -785,8 +785,12 @@ spotifyApi.getAvailableGenreSeeds()
 /* Player */
 
 // Add an Item to the User's Playback Queue
-// TBD
-
+spotifyApi.addToQueue('spotify:track:2LMloFiV7DHpBhITOaBSam')
+  .then(function(data) {
+    console.log('Song added to queue!')
+  }, function(err) {
+    console.log('Something went wrong!', err)
+  })
 
 // Get a User's Queue
 spotifyApi.getMyQueue()

--- a/__tests__/spotify-web-api.js
+++ b/__tests__/spotify-web-api.js
@@ -1721,6 +1721,28 @@ describe('Spotify Web API', () => {
     });
   });
 
+  test("should get the user's queue:", done => {
+    sinon.stub(HttpManager, '_makeRequest').callsFake(function(
+      method,
+      options,
+      uri,
+      callback
+    ) {
+      expect(method).toBe(superagent.get);
+      expect(uri).toBe('https://api.spotify.com/v1/me/player/queue')
+      expect(options.query).toEqual(null)
+      expect(options.headers).toEqual({ Authorization: 'someAccessToken'  })
+    })
+
+    var api = new SpotifyWebApi({
+      accessToken: 'someAccessToken'
+    })
+
+    api.getMyQueue().then(function(data) {
+      done();
+    })
+  })
+
   test("should add songs to the user's queue:", done => {
     sinon.stub(HttpManager, '_makeRequest').callsFake(function(
       method,

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -949,6 +949,22 @@ SpotifyWebApi.prototype = {
       .execute(HttpManager.get, callback);
   },
 
+  /** 
+   * Get the Current User's Queue
+   * @param {Object} [options] Options, being type, after, limit, before.
+   * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+   * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of play history objects,
+   *          otherwise an error. Not returned if a callback is given. Note that the response will be empty
+   *          in case the user has enabled private session.
+  */
+  getMyQueue: function(options, callback) {
+    return WebApiRequest.builder(this.getAccessToken())
+      .withPath('/v1/me/player/queue')
+      .withQueryParameters(options)
+      .build()
+      .execute(HttpManager.get, callback)
+  },
+
   /**
    * Add track or episode to device queue
    * @param {string} [uri] uri of the track or episode to add


### PR DESCRIPTION
[spotify documentation](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue)