### PR TITLE
Add missing get Queue API Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,15 @@ spotifyApi.getMyCurrentPlayingTrack()
     console.log('Something went wrong!', err);
   });
 
+// Get the User's Queue + Current Playing Track 
+spotifyApi.getMyQueue()
+  .then(function(data) {
+    console.log('Now playing: ' + data.body.currently_playing.name);
+    console.log('Queue length: ' + data.body.queue.length());
+  }, function(err) {
+    console.log('Something went wrong!', err);
+  });
+
 // Pause a User's Playback
 spotifyApi.pause()
   .then(function() {

--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -218,6 +218,19 @@ SpotifyWebApi.prototype = {
   },
 
   /**
+   * Get the User’s Queue.
+   * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
+   * @returns {Promise|undefined} A promise that if successful, resolves into a paging object of tracks,
+   *          otherwise an error. Not returned if a callback is given.
+   */
+    getMyQueue: function(  callback) {
+      return WebApiRequest.builder(this.getAccessToken())
+        .withPath('/v1/me/player/queue')
+        .build()
+        .execute(HttpManager.get, callback);
+    },
+
+  /**
    * Search for music entities of certain types.
    * @param {string} query The search query.
    * @param {string[]} types An array of item types to search across.


### PR DESCRIPTION
Here is a new API Endpoint in current Spotify's API Docs:
https://developer.spotify.com/documentation/web-api/reference/#/operations/get-queue

I added it to the Lib.