### PR TITLE
#471 [WebApiError] Error message type should be a string

### DIFF
--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -44,7 +44,7 @@ var _toError = function(response) {
   }
   
   /* Other type of error, or unhandled Web API error format */
-  return new WebapiError(response.body, response.headers, response.statusCode, response.body);
+  return new WebapiError(response.body, response.headers, response.statusCode, 'An error occurred while communicating with Spotify\'s Web API.');
 };
 
 /* Make the request to the Web API */


### PR DESCRIPTION
https://github.com/thelinmichael/spotify-web-api-node/issues/471