### PR TITLE
chore: report non-JSON error from API

### DIFF
--- a/src/http-manager.js
+++ b/src/http-manager.js
@@ -44,7 +44,7 @@ var _toError = function(response) {
   }
   
   /* Other type of error, or unhandled Web API error format */
-  return new WebapiError(response.body, response.headers, response.statusCode, response.body);
+  return new WebapiError(response.body, response.headers, response.statusCode, response.text || response.body);
 };
 
 /* Make the request to the Web API */


### PR DESCRIPTION
Certain classes of errors return non-JSON responses, leading to errors like these:

```console
WebapiError: [object Object]
    at _toError (<project>/node_modules/spotify-web-api-node/src/http-manager.js:48:10)
    at <project>/node_modules/spotify-web-api-node/src/http-manager.js:72:25
    at Request.callback (<project>/node_modules/superagent/lib/node/index.js:905:3)
    at IncomingMessage.<anonymous> (<project>/node_modules/superagent/lib/node/index.js:1127:20)
    at Stream.emit (node:events:513:28)
    at Unzip.<anonymous> (<project>/node_modules/superagent/lib/node/unzip.js:53:12)
    at Unzip.emit (node:events:513:28)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  body: {},
  headers: { ... },
  statusCode: 403
}
```

this patch makes it so we report the textual errors in the case that there are any.

```console
WebapiError: User not registered in the Developer Dashboard
    at _toError (<project>/node_modules/spotify-web-api-node/src/http-manager.js:48:10)
    at <project>/node_modules/spotify-web-api-node/src/http-manager.js:72:25
    at Request.callback (<project>/node_modules/superagent/lib/node/index.js:905:3)
    at IncomingMessage.<anonymous> (<project>/node_modules/superagent/lib/node/index.js:1127:20)
    at Stream.emit (node:events:513:28)
    at Unzip.<anonymous> (<project>/node_modules/superagent/lib/node/unzip.js:53:12)
    at Unzip.emit (node:events:513:28)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  body: {},
  headers: { ... },
  statusCode: 403
}
```