### PR TITLE
feat: add support for default request headers

### DIFF
--- a/src/spotify-web-api.js
+++ b/src/spotify-web-api.js
@@ -21,6 +21,10 @@ SpotifyWebApi.prototype = {
     return this._credentials;
   },
 
+  setDefaultHeaders: function(defaultHeaders) {
+    WebApiRequest.setDefaultHeaders(defaultHeaders);
+  },
+
   resetCredentials: function() {
     this._credentials = null;
   },
@@ -593,7 +597,7 @@ SpotifyWebApi.prototype = {
       .withBodyParameters(
         {
           tracks: tracks
-        }, 
+        },
         options
       )
       .build()
@@ -971,7 +975,7 @@ SpotifyWebApi.prototype = {
   },
 
 
-  /** 
+  /**
    * Get the Current User's Available Devices
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
    * @returns {Promise|undefined} A promise that if successful, resolves into an array of device objects,
@@ -1016,7 +1020,7 @@ SpotifyWebApi.prototype = {
 
   /**
    * Transfer a User's Playback
-   * @param {string[]} [deviceIds] An _array_ containing a device ID on which playback should be started/transferred. 
+   * @param {string[]} [deviceIds] An _array_ containing a device ID on which playback should be started/transferred.
    * (NOTE: The API is currently only supporting a single device ID.)
    * @param {Object} [options] Options, the only one being 'play'.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
@@ -1175,7 +1179,7 @@ SpotifyWebApi.prototype = {
 
   /**
    * Set Shuffle Mode On The Current User's Playback
-   * @param {boolean} [state] State 
+   * @param {boolean} [state] State
    * @param {Object} [options] Options, being device_id. If left empty will target the user's currently active device.
    * @param {requestCallback} [callback] Optional callback method to be called instead of the promise.
    * @example setShuffle({state: 'false'}).then(...)

--- a/src/webapi-request.js
+++ b/src/webapi-request.js
@@ -6,10 +6,17 @@ var DEFAULT_HOST = 'api.spotify.com',
   DEFAULT_PORT = 443,
   DEFAULT_SCHEME = 'https';
 
+let defaultHeaders = null;
+
 module.exports.builder = function(accessToken) {
   return Request.builder()
     .withHost(DEFAULT_HOST)
     .withPort(DEFAULT_PORT)
     .withScheme(DEFAULT_SCHEME)
+    .withHeaders(defaultHeaders)
     .withAuth(accessToken);
 };
+
+module.exports.setDefaultHeaders = function(headers) {
+  defaultHeaders = headers;
+}


### PR DESCRIPTION
Solution for #506 - possibility to set default headers for all API requests, e.g `Accept-Language`

```js
const api = new SpotifyWebApi();
api.setDefaultHeaders({'Accept-Language': 'ru'});
```

So it will correctly fetch artists names, written in their native language. For example:

|Before:|After:|
|-|-|
|![Screen Shot 2024-09-02 at 23 15 04](https://github.com/user-attachments/assets/9191a105-ee55-451d-ac41-d58803fbb9c7) | ![Screen Shot 2024-09-02 at 23 07 35](https://github.com/user-attachments/assets/d5ae5966-68aa-453f-abc1-78ba13657f5b) |

